### PR TITLE
Matrix update fix

### DIFF
--- a/iced/_filter_.pyx
+++ b/iced/_filter_.pyx
@@ -20,7 +20,7 @@ def _filter_csr(X, np.ndarray[INT, ndim=1] bias):
 
     j = 0
     for i, row in enumerate(X_indices):
-        if i >= X_indptr[j + 1]:
+        while i >= X_indptr[j + 1]:
             j += 1
         if bias[row] or bias[j]:
             X_data[i] = 0


### PR DESCRIPTION
Incrementing only once _j_ might be not enough.
Like in [_update_normalization_csr](https://github.com/hiclib/iced/blob/master/iced/_normalization_.pyx), _j_ has to be incremented until the _j_-th column contains _X_data[i]_.