### PR TITLE
update of remove_all_zeros_bin

### DIFF
--- a/iced/filter.py
+++ b/iced/filter.py
@@ -155,7 +155,8 @@ def _filter_low_sum(X, percentage=0.02, remove_all_zeros_loci=False,
         x = X_sum[int(m * percentage)]
     else:
         num_noninteracting_loci = sum(X_sum == 0)
-        x = X_sum[int(m * percentage) + num_noninteracting_loci]
+        x = X_sum[int(len(X_sum[X_sum > 0]) * percentage) + num_noninteracting_loci]
+
 
     X_sum = np.array(X.sum(axis=0)).flatten()
 

--- a/iced/scripts/ice
+++ b/iced/scripts/ice
@@ -85,12 +85,12 @@ if filter_low_counts_perc != 0:
     counts = iced.filter.filter_low_counts(counts,
                                            percentage=filter_low_counts_perc,
                                            remove_all_zeros_loci=args.remove_all_zeros_loci,
-                                           copy=False, sparsity=False)
+                                           copy=False, sparsity=False, verbose=args.verbose)
 if args.filter_high_counts_perc != 0:
     counts = iced.filter.filter_high_counts(
         counts,
         percentage=args.filter_high_counts_perc,
-        copy=False)
+        copy=False, verbose=args.verbose)
 
 counts, bias = iced.normalization.ICE_normalization(
     counts, max_iter=args.max_iter, copy=False,

--- a/iced/scripts/ice
+++ b/iced/scripts/ice
@@ -71,8 +71,20 @@ if args.verbose:
 
 # Loads file as i, j, counts
 i, j, data = loadtxt(filename).T
-N = max(i.max(), j.max()) + 1
-counts = sparse.coo_matrix((data, (i, j)), shape=(N, N), dtype=float)
+
+## zero-based data
+if min(i.min(), j.min()) == 0:
+    if args.vecbose:
+        print "Detecting zero-based data ..."
+    N = max(i.max(), j.max()) + 1
+    counts = sparse.coo_matrix((data, (i, j)), shape=(N, N), dtype=float)
+else:
+## one-based data
+    if args.verbose:
+            print "Detecting one-based data ..."
+    N = max(i.max(), j.max())
+    counts = sparse.coo_matrix((data, (i - 1, j - 1)), shape=(N, N), dtype=float)
+
 if args.dense:
     counts = np.array(counts.todense())
 else:
@@ -90,7 +102,7 @@ if args.filter_high_counts_perc != 0:
     counts = iced.filter.filter_high_counts(
         counts,
         percentage=args.filter_high_counts_perc,
-        copy=False, verbose=args.verbose)
+        copy=False)
 
 counts, bias = iced.normalization.ICE_normalization(
     counts, max_iter=args.max_iter, copy=False,
@@ -106,7 +118,13 @@ counts = sparse.coo_matrix(counts)
 
 if args.verbose:
     print "Writing results..."
-savetxt(results_filename, counts.col, counts.row, counts.data)
+
+## Results are now zero based - save as one based
+if min(i.min(), j.min()) == 0:
+    savetxt(results_filename, counts.col, counts.row, counts.data)
+else:
+    savetxt(results_filename, counts.col + 1, counts.row + 1, counts.data)
+
 
 if args.output_bias:
     np.savetxt(results_filename + ".biases", bias)


### PR DESCRIPTION
In the current version 
 -        x = X_sum[int(m * percentage) + num_noninteracting_loci] 
did not work for some samples ('out of range error'.
The reason is that 'm' should be the length of non-zeros values.
