### PR TITLE
added pyproject.toml to specify build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires=['setuptools', 'wheel', 'numpy']


### PR DESCRIPTION
This addresses #76 by adding a minimal `pyproject.toml` that specifies an build-time dependency on numpy.

This was tested by running

```
$ pip install git+https://github.com/thomasgilgenast/iced.git
```

in an empty virtual environment.