### PR TITLE
added pyproject.toml to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 recursive-include iced *.c *.h *.py
 recursive-include *.matrix *.bed
+include pyproject.toml


### PR DESCRIPTION
This PR is a follow-up to #77, which added a `pyproject.toml` file (to address #76) but neglected to include it in the sdist by listing it in `MANIFEST.in`. This PR lists `pyproject.toml` in `MANIFEST.in`, ensuring that it does get included in the sdist.