### PR TITLE
Support NumPy 1.24+

### DIFF
--- a/iced/filter.py
+++ b/iced/filter.py
@@ -52,7 +52,7 @@ def filter_low_counts(X, lengths=None, percentage=0.02, copy=True,
             mask = utils.get_inter_mask(lengths)
         else:
             weights = np.ones(X.shape[0])
-            mask = np.zeros(X.shape, dtype=np.bool)
+            mask = np.zeros(X.shape, dtype=bool)
 
         return _filter_low_sparse(X, weights, mask, percentage=percentage,
                                   remove_all_zeros_loci=remove_all_zeros_loci,

--- a/iced/normalization/__init__.py
+++ b/iced/normalization/__init__.py
@@ -57,7 +57,7 @@ def ICE_normalization(X, SS=None, max_iter=3000, eps=1e-4, copy=True,
 
     if sparse.issparse(X):
         if not sparse.isspmatrix_coo(X):
-            X = sparse.coo_matrix(X, dtype="float")
+            X = sparse.coo_matrix(X, dtype=float)
     else:
         X[np.isnan(X)] = 0
     X = X.astype('float')

--- a/iced/random/__init__.py
+++ b/iced/random/__init__.py
@@ -28,7 +28,7 @@ def downsample_contact_map(counts, nreads=None, proportion=None,
     -------
     c : downsampled contact count matrix as a COO matrix.
     """
-    if counts.dtype != "int":
+    if not np.issubdtype(counts.dtype, np.integer):
         if np.abs(counts - np.round(counts)).sum() != 0:
             raise ValueError("Count matrix should be integers")
         counts = counts.astype("int")
@@ -92,7 +92,7 @@ def bootstrap_contact_map(counts, random_state=None):
     -------
     c : downsampled contact count matrix as a COO matrix.
     """
-    if counts.dtype != "int":
+    if not np.issubdtype(counts.dtype, np.integer):
         if np.abs(counts - np.round(counts)).sum() != 0:
             raise ValueError("Count matrix should be integers")
         counts = counts.astype("int")


### PR DESCRIPTION
NumPy 1.20 [deprecated](https://numpy.org/doc/stable/release/1.20.0-notes.html#deprecations) several dtype aliases like `np.int`. These aliases have been removed with NumPy 1.24.0 (see last bullet point under "Expired Deprecations" [here](https://github.com/numpy/numpy/releases/tag/v1.24.0)).

This PR updates the dtypes used throughout the library, so that iced can be used with the latest NumPy.